### PR TITLE
Flexibly convert column names to camelCase when reading csv files. 

### DIFF
--- a/R/CohortDefinitionSet.R
+++ b/R/CohortDefinitionSet.R
@@ -253,7 +253,7 @@ getCohortDefinitionSet <- function(settingsFileName = "Cohorts.csv",
 
   # Read the settings file which holds the cohortDefinitionSet
   ParallelLogger::logInfo("Loading cohortDefinitionSet")
-  settings <- readCsv(file = getPath(fileName = settingsFileName))
+  settings <- readCsv(file = getPath(fileName = settingsFileName), warnOnCaseMismatch = FALSE)
 
   assert_settings_columns(names(settings), getPath(fileName = settingsFileName))
   checkmate::assert_true(all(cohortFileNameValue %in% names(settings)))

--- a/R/CsvHelper.R
+++ b/R/CsvHelper.R
@@ -41,7 +41,8 @@ readCsv <- function(file, warnOnCaseMismatch = TRUE) {
     problemColumnsWarning <- paste(problemColumns, collapse = ", ")
     warning(paste("The following columns were not in snake case format:", problemColumnsWarning))
   }
-  colnames(fileContents) <- SqlRender::snakeCaseToCamelCase(colnames(fileContents))
+  colIdxToConvert <- which(isSnakeCase(columnNames))
+  names(fileContents)[colIdxToConvert] <- SqlRender::snakeCaseToCamelCase(names(fileContents)[colIdxToConvert])
   invisible(fileContents)
 }
 


### PR DESCRIPTION
Fixes #37