### PR TITLE
cast inclusionRules.cohortDefinitionId, ruleSequence as integers

### DIFF
--- a/R/CohortStats.R
+++ b/R/CohortStats.R
@@ -93,8 +93,8 @@ insertInclusionRuleNames <- function(connectionDetails = NULL,
           inclusionRules <- rbind(
             inclusionRules,
             data.frame(
-              cohortDefinitionId = cohortDefinitionSet$cohortId[i],
-              ruleSequence = j - 1,
+              cohortDefinitionId = as.integer(cohortDefinitionSet$cohortId[i]),
+              ruleSequence = as.integer(j - 1),
               name = ruleName,
               description = ruleDescription
             )


### PR DESCRIPTION
Explicit is.integer() casting  eliminates TYPE error in BigQuery and ensures asserted values always match CREATE TABLE column data type declarations. Fixes Issue #51 

![CohortGenerator_datatype_error](https://user-images.githubusercontent.com/3923918/179867203-e0f4bc98-16bc-47c7-b878-acd5ed232776.PNG)
