### PR TITLE
Casting of cohort_definition_id when inserting inclusion rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Depends:
   DatabaseConnector (>= 5.0.0),
   R (>= 3.6.0)
 Imports:
+  bit64,
   checkmate,
   digest,
   dplyr,

--- a/R/CohortDefinitionSet.R
+++ b/R/CohortDefinitionSet.R
@@ -38,7 +38,11 @@ createEmptyCohortDefinitionSet <- function(verbose = FALSE) {
   for (i in 1:nrow(cohortDefinitionSetSpec)) {
     colName <- cohortDefinitionSetSpec$columnName[i]
     dataType <- cohortDefinitionSetSpec$dataType[i]
-    df <- df %>% dplyr::mutate(!!colName := do.call(what = dataType, args = list()))
+    if (dataType == "integer64") {
+      df <- df %>% dplyr::mutate(!!colName := do.call(what = bit64::as.integer64, args = list()))
+    } else {
+      df <- df %>% dplyr::mutate(!!colName := do.call(what = dataType, args = list()))
+    }
   }
   invisible(df)
 }

--- a/R/CohortStats.R
+++ b/R/CohortStats.R
@@ -69,7 +69,7 @@ insertInclusionRuleNames <- function(connectionDetails = NULL,
   # NOTE: This data frame must match the @cohort_inclusion_table
   # structure as defined in inst/sql/sql_server/CreateCohortTables.sql
   inclusionRules <- data.frame(
-    cohortDefinitionId = integer(),
+    cohortDefinitionId = bit64::integer64(),
     ruleSequence = integer(),
     name = character(),
     description = character()
@@ -93,7 +93,7 @@ insertInclusionRuleNames <- function(connectionDetails = NULL,
           inclusionRules <- rbind(
             inclusionRules,
             data.frame(
-              cohortDefinitionId = as.integer(cohortDefinitionSet$cohortId[i]),
+              cohortDefinitionId = bit64::as.integer64(cohortDefinitionSet$cohortId[i]),
               ruleSequence = as.integer(j - 1),
               name = ruleName,
               description = ruleDescription

--- a/inst/cohortDefinitionSetSpecificationDescription.csv
+++ b/inst/cohortDefinitionSetSpecificationDescription.csv
@@ -1,5 +1,5 @@
 column_name,description,data_type
-cohortId,The identifier for the cohort in the cohort definition set.,integer
+cohortId,The identifier for the cohort in the cohort definition set.,integer64
 cohortName,The name of the cohort in the cohort definition set.,character
 sql,The SQL code used to construct the cohort,character
 json,The optional Circe compliant JSON representation of the cohort definition.,character


### PR DESCRIPTION
This PR is a draft at this point - just raising it for awareness for @mgkahn and @azimov. My plan is to add unit tests to ensure that cohort_definition_ids that are INT64 are honored. 