### PR TITLE
Revise cohort subset addition logic - fixes #83

### DIFF
--- a/R/SubsetDefinitions.R
+++ b/R/SubsetDefinitions.R
@@ -330,21 +330,21 @@ addCohortSubsetDefinition <- function(cohortDefinitionSet,
 
   # Remove any cohorts that use this id
   findSubsetIndexById <- function(existingSubsetDefinitions, id) {
-    ind <- sapply(existingSubsetDefinitions, function(y) existingSubsetDefinitions$definitionId == id)
-    if (length(ind) > 0) {
-      ind <- which(ind)
-    } else {
-      ind <- NA
+    if (length(existingSubsetDefinitions)) {
+      for (i in 1:length(existingSubsetDefinitions)) {
+        if (existingSubsetDefinitions[[i]]$definitionId == id)
+          return(i)
+      }
     }
-    return(ind)
-  }
+    return(NA)
+  } 
   
   subsetIndex <- findSubsetIndexById(existingSubsetDefinitions, subsetDefinitionCopy$definitionId)
   if (!is.na(subsetIndex)) {
     if (overwriteExisting) {
       # Remove any cohorts that were created with this definition
       cohortDefinitionSet <- cohortDefinitionSet %>%
-        dplyr::filter(.data$subsetDefinitionId != subsetDefinitionCopy$definitionId)
+        dplyr::filter(is.na(.data$subsetDefinitionId) | .data$subsetDefinitionId != subsetDefinitionCopy$definitionId)
     } else {
       stop("Existing definition of id ", subsetDefinitionCopy$definitionId,
            " already applied to set, use overwriteExisting = TRUE to re-apply or change definition id")

--- a/R/SubsetDefinitions.R
+++ b/R/SubsetDefinitions.R
@@ -329,7 +329,18 @@ addCohortSubsetDefinition <- function(cohortDefinitionSet,
   subsetDefinitionCopy <- cohortSubsetDefintion$clone(deep = TRUE)
 
   # Remove any cohorts that use this id
-  if (!is.null(existingSubsetDefinitions[subsetDefinitionCopy$definitionId][[1]])) {
+  findSubsetIndexById <- function(existingSubsetDefinitions, id) {
+    ind <- sapply(existingSubsetDefinitions, function(y) existingSubsetDefinitions$definitionId == id)
+    if (length(ind) > 0) {
+      ind <- which(ind)
+    } else {
+      ind <- NA
+    }
+    return(ind)
+  }
+  
+  subsetIndex <- findSubsetIndexById(existingSubsetDefinitions, subsetDefinitionCopy$definitionId)
+  if (!is.na(subsetIndex)) {
     if (overwriteExisting) {
       # Remove any cohorts that were created with this definition
       cohortDefinitionSet <- cohortDefinitionSet %>%
@@ -338,9 +349,11 @@ addCohortSubsetDefinition <- function(cohortDefinitionSet,
       stop("Existing definition of id ", subsetDefinitionCopy$definitionId,
            " already applied to set, use overwriteExisting = TRUE to re-apply or change definition id")
     }
+  } else {
+    subsetIndex <- length(existingSubsetDefinitions) + 1
   }
 
-  existingSubsetDefinitions[[subsetDefinitionCopy$definitionId]] <- subsetDefinitionCopy
+  existingSubsetDefinitions[[subsetIndex]] <- subsetDefinitionCopy
   attr(cohortDefinitionSet, "cohortSubsetDefinitions") <- existingSubsetDefinitions
 
   subsetDefinitionCopy$setTargetOutputPairs(targetCohortIds)

--- a/R/SubsetQueryBuilders.R
+++ b/R/SubsetQueryBuilders.R
@@ -65,7 +65,6 @@ CohortSubsetQb <- R6::R6Class(
                                                       yes = 1,
                                                       no = length(private$operator$cohortIds)),
                                warnOnMissingParameters = TRUE)
-      SqlRender::writeSql(sql, "cohort_subset_sub_query.sql")
       return(sql)
     }
   )
@@ -92,7 +91,6 @@ LimitSubsetQb <- R6::R6Class(
                                output_table = self$getTableObjectId(),
                                target_table = targetTable,
                                warnOnMissingParameters = TRUE)
-      #SqlRender::writeSql(sql, "limit_sub_query.sql")
       return(sql)
     }
   )
@@ -113,7 +111,6 @@ DemographicSubsetQb <- R6::R6Class(
                                race_concept_id = private$operator$getRace(),
                                ethnicity_concept_id = private$operator$getEthnicity(),
                                warnOnMissingParameters = TRUE)
-      #SqlRender::writeSql(sql, "demographics_sub_query.sql")
       return(sql)
     }
   )

--- a/tests/testthat/test-Subsets.R
+++ b/tests/testthat/test-Subsets.R
@@ -265,3 +265,34 @@ test_that("Subset definition creation and retrieval with definitionId != 1", {
   sampleSubsetDefinitions <- CohortGenerator::getSubsetDefinitions(sampleCohortsWithSubsets)
   expect_equal(length(sampleSubsetDefinitions), 1)
 })
+
+test_that("Test overwriteExisting", {
+  cohortDefinitionSet <- getCohortDefinitionSet(settingsFileName = "testdata/name/Cohorts.csv",
+                                                jsonFolder = "testdata/name/cohorts",
+                                                sqlFolder = "testdata/name/sql/sql_server",
+                                                cohortFileNameFormat = "%s",
+                                                cohortFileNameValue = c("cohortName"),
+                                                packageName = "CohortGenerator",
+                                                verbose = FALSE)
+  subsetOperations <- list(
+    createDemographicSubset(id = 1001,
+                            name = "Demographic Criteria",
+                            ageMin = 18,
+                            ageMax = 64)
+  )
+  subsetDef <- createCohortSubsetDefinition(name = "test definition",
+                                            definitionId = 1,
+                                            subsetOperators = subsetOperations)
+
+  # Expect to work the 1st time
+  cohortDefinitionSetWithSubset <- cohortDefinitionSet %>%
+    CohortGenerator::addCohortSubsetDefinition(subsetDef)
+  
+  # Expect to fail the 2nd time
+  expect_error(CohortGenerator::addCohortSubsetDefinition(cohortDefinitionSetWithSubset, subsetDef))
+  
+  # Use the overwrite option
+  cohortDefinitionSetWithSubset2 <- cohortDefinitionSetWithSubset %>%
+    CohortGenerator::addCohortSubsetDefinition(subsetDef, overwriteExisting = TRUE)
+})
+

--- a/tests/testthat/test-Subsets.R
+++ b/tests/testthat/test-Subsets.R
@@ -232,3 +232,36 @@ test_that("subset generation", {
   expect_true(all(cohortsGenerated$generationStatus == "SKIPPED"))
   unlink(recordKeepingFolder, recursive = TRUE)
 })
+
+test_that("Subset definition creation and retrieval with definitionId != 1", {
+  sampleCohorts <- CohortGenerator::createEmptyCohortDefinitionSet()
+  cohortJsonFiles <- list.files(path = system.file("testdata/name/cohorts", package = "CohortGenerator"), full.names = TRUE)
+  cohortJsonFileName <- cohortJsonFiles[1]
+  cohortName <- tools::file_path_sans_ext(basename(cohortJsonFileName))
+  cohortJson <- readChar(cohortJsonFileName, file.info(cohortJsonFileName)$size)
+  sampleCohorts <- rbind(sampleCohorts, data.frame(
+    cohortId = as.double(1),
+    cohortName = cohortName,
+    json = cohortJson,
+    sql = "",
+    stringsAsFactors = FALSE
+  ))
+  
+  
+  # Limit to male only
+  subsetDef2 <- CohortGenerator::createCohortSubsetDefinition(
+    name ="Male Only",
+    definitionId = 2,
+    subsetOperators = list(
+      CohortGenerator::createDemographicSubset(id = 4,
+                                               name = "Male",
+                                               gender = 8507)
+    )
+  )
+  
+  sampleCohortsWithSubsets <- sampleCohorts %>%
+    CohortGenerator::addCohortSubsetDefinition(subsetDef2)
+  
+  sampleSubsetDefinitions <- CohortGenerator::getSubsetDefinitions(sampleCohortsWithSubsets)
+  expect_equal(length(sampleSubsetDefinitions), 1)
+})


### PR DESCRIPTION
Change the way in which we add subset definitions to a cohort definition set to use a relative index vs. using the subset definition `definitionId` directly.

Also removes the statements for writing out SQL based on testing this functionality.