### PR TITLE
Subset operator id assignment resolved

### DIFF
--- a/R/SubsetDefinitions.R
+++ b/R/SubsetDefinitions.R
@@ -75,7 +75,7 @@ CohortSubsetDefinition <- R6::R6Class(
     #' @param overwrite if a subset operator of the same ID is present, replace it with a new definition
     addSubsetOperator = function(subsetOperator) {
       checkmate::assertR6(subsetOperator, "SubsetOperator")
-      existingOperator <- self$getSubsetOperatorById(!subsetOperator$id)
+      existingOperator <- self$getSubsetOperatorById(subsetOperator$id)
       if (is.null(existingOperator)) {
         private$.subsetOperators <- c(private$.subsetOperators, subsetOperator)
         private$.subsetIds <- c(private$.subsetIds, subsetOperator$id)
@@ -91,7 +91,7 @@ CohortSubsetDefinition <- R6::R6Class(
     getSubsetOperatorById = function(id) {
       # This implementation seems weird but if you store int ids in a list then R will store every int lower than that
       # Value as a NULL, which breaks any calls to "x %in% names(listObj)"
-      if (!id %in% private$.subsetId) {
+      if (!id %in% private$.subsetIds) {
         return(NULL)
       }
 

--- a/R/Subsets.R
+++ b/R/Subsets.R
@@ -133,7 +133,8 @@ SubsetOperator <- R6::R6Class(
     queryBuilder = QueryBuilder,
     suffixStr = "S",
     .name = "",
-    .id = NA
+    .id = NA,
+    baseFields = c("name", "id")
   ),
 
   public = list(
@@ -143,7 +144,6 @@ SubsetOperator <- R6::R6Class(
     initialize = function(definition = NULL) {
       if (!is.null(definition)) {
         definition <- .loadJson(definition)
-
         for (field in names(definition)) {
           if (field %in% self$publicFields()) {
             self[[field]] <- definition[[field]]
@@ -166,7 +166,8 @@ SubsetOperator <- R6::R6Class(
     #' Public Fields
     #' @description Publicly settable fields of object
     publicFields = function() {
-      return(names(get(self$classname())$active))
+      # Note that this will probably break if you subclass a subclass
+      return(c(private$baseFields, names(get(self$classname())$active)))
     },
 
     #' Is Equal to
@@ -260,12 +261,6 @@ CohortSubsetOperator <- R6::R6Class(
     .endWindow = SubsetCohortWindow$new()
   ),
   public = list(
-    #' Public Fields
-    #' @description publicly settable fields
-    publicFields = function() {
-      c(super$publicFields(), "cohortIds", "cohortCombinationOperator", "negate", "startWindow", "endWindow")
-    },
-
     #' to List
     #' @description List representation of object
     toList = function() {
@@ -385,10 +380,6 @@ DemographicSubsetOperator <- R6::R6Class(
     .ethnicity = NULL
   ),
   public = list(
-    #' @description Publicly settable fields of object
-    publicFields = function() {
-      c(super$publicFields(), "ageMin", "ageMax", "gender", "race", "ethnicity")
-    },
     #' @description List representation of object
     toList = function() {
       objRepr <- super$toList()
@@ -541,10 +532,6 @@ LimitSubsetOperator <- R6::R6Class(
     .calendarEndDate = NULL
   ),
   public = list(
-    #' @description Publicly settable fields of object
-    publicFields = function() {
-      c(super$publicFields(), "priorTime", "followUpTime", "limitTo", "calendarStartDate", "calendarEndDate")
-    },
     #' To List
     #' @description List representation of object
     toList = function() {

--- a/tests/testthat/test-Subsets.R
+++ b/tests/testthat/test-Subsets.R
@@ -39,9 +39,11 @@ test_that("Subset definition", {
   expect_equal(length(subsetDef$subsetOperators), length(listDef$subsetOperators))
   checkmate::expect_character(subsetDef$toJSON())
 
+
   # Check serialized version is identical to code defined version
   subsetDef2 <- CohortSubsetDefinition$new(subsetDef$toJSON())
 
+  expect_equal(subsetDef2$toJSON(), subsetDef$toJSON())
   checkmate::expect_class(subsetDef2, "CohortSubsetDefinition")
   expect_equal(length(subsetDef2$subsetOperators), length(subsetDef$subsetOperators))
 

--- a/tests/testthat/test-Subsets.R
+++ b/tests/testthat/test-Subsets.R
@@ -89,6 +89,37 @@ test_that("Subset definition", {
                             startWindow = createSubsetCohortWindow(-99999, 99999, "cohortStart"),
                             end = createSubsetCohortWindow(-99999, 99999, "cohortEnd"))
   expect_false(testDemoSubset2$isEqualTo(testDemoSubset))
+  
+  # Attempt to add an existing operator to a cohort subset definition
+  csd <- createCohortSubsetDefinition(name = "Test cohort subset definition",
+                                      definitionId = 1,
+                                      subsetOperators = list(ccs))
+  
+  expect_error(csd$addSubsetOperator(ccs))
+  
+  
+  # Create a cohort subset operator that does not reference a cohort ID
+  # in the cohort definition set
+  invalidCohortSubsetOperator <- createCohortSubset(id = 2001,
+                                                    name = "Invalid Cohort Subset",
+                                                    cohortIds = 0,
+                                                    cohortCombinationOperator = "all",
+                                                    negate = FALSE,
+                                                    startWindow = createSubsetCohortWindow(-99999, 99999, "cohortStart"),
+                                                    end = createSubsetCohortWindow(-99999, 99999, "cohortEnd"))
+  invalidCohortSubsetDefintion <- createCohortSubsetDefinition(
+    name = "Invalid cohort subset definition",
+    definitionId = 100,
+    identifierExpression = expression(targetId), # This expression will yield duplicate IDs by design
+    subsetOperators = list(invalidCohortSubsetOperator)
+  )
+  
+  expect_error(addCohortSubsetDefinition(cohortDefinitionSet = cohortDefinitionSet, 
+                                         cohortSubsetDefintion = invalidCohortSubsetDefintion))
+  
+  invalidCohortSubsetOperator$id <- 2002
+  invalidCohortSubsetOperator2 <- csd$addSubsetOperator(invalidCohortSubsetOperator)
+  expect_equal(invalidCohortSubsetOperator2$toJSON(), csd$toJSON())
 })
 
 
@@ -298,3 +329,59 @@ test_that("Test overwriteExisting", {
     CohortGenerator::addCohortSubsetDefinition(subsetDef, overwriteExisting = TRUE)
 })
 
+test_that("Subset operator serialization tests", {
+  # Confirm .loadJson fails when a non-list object is passed
+  expect_error(CohortGenerator:::.loadJson(definition = 1))
+  
+  # Subset Window
+  sw1 <- createSubsetCohortWindow(-99999, 99999, "cohortStart")
+  sw2 <- createSubsetCohortWindow(-99999, 99999, "cohortEnd")
+  
+  expect_false(sw1$isEqualTo(sw2))
+  expect_silent(sw1$toJSON())
+  
+  # SubsetOperator base class tests
+  so1 <- SubsetOperator$new()
+  so1$id <- 1
+  so1$name <- "SubsetOp1"
+  
+  so2 <- SubsetOperator$new()
+  so2$name <- "SubsetOp2"
+  
+  ds1<- createDemographicSubset(id = 1001,
+                                name = "Demographic Criteria",
+                                ageMin = 18,
+                                ageMax = 64,
+                                gender = 8532,
+                                race = 8527,
+                                ethnicity = 38003563)
+  
+  expect_warning(so1$isEqualTo(ds1))
+  expect_false(so1$isEqualTo(so2))
+  expect_false(so2$isEqualTo(so1))
+  expect_silent(so1$toJSON())
+  expect_silent(so2$toJSON())
+  expect_silent(ds1$toJSON())
+  
+  # Test getters
+  expect_equal(ds1$getRace(), 8527)
+  expect_equal(ds1$getEthnicity(), 38003563)
+  
+  ls1 <- createLimitSubset(id = 1002,
+                           name = "Limit Subset 1",
+                           priorTime = 365,
+                           followUpTime = 0,
+                           limitTo = "firstEver",
+                           calendarStartDate = "",
+                           calendarEndDate = "")
+  expect_silent(ls1$toJSON())
+
+  ls2 <- createLimitSubset(id = 1003,
+                           name = "Limit Subset 2",
+                           priorTime = 365,
+                           followUpTime = 0,
+                           limitTo = "firstEver",
+                           calendarStartDate = "2000-01-01",
+                           calendarEndDate = "2013-12-31")
+  expect_silent(ls2$toJSON())  
+})


### PR DESCRIPTION
The problem was with the way the public fields were being set - originally I was using a static list for all the files but then changed to using the class definition directly. This mismatch meant that the base fields (id, name) weren't being set.

This will probably fail if we start subclassing subclasses here but I don't think that will be hard to resolve when we do it.