### PR TITLE
Do not eval ROhdsiWebApi call - fixes #70

### DIFF
--- a/vignettes/CreatingCohortSubsetDefinitions.Rmd
+++ b/vignettes/CreatingCohortSubsetDefinitions.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Creating Cohort Subset Definitions"
-author: "James P. Gilbert"
+author: "James P. Gilbert and Anthony G. Sena"
 date: "`r Sys.Date()`"
 output:
   html_document:
@@ -25,6 +25,7 @@ knitr::opts_chunk$set(
 someFolder <- tempdir()
 packageRoot <- tempdir()
 baseUrl <- "https://api.ohdsi.org/WebAPI"
+library(CohortGenerator)
 ```
 # Introduction
 This guide aims to describe the process of cohort subsetting using `CohortGenerator`.
@@ -55,7 +56,7 @@ This type of operation allows you to subset a cohort to only those subjects incl
 
 ## Defining a subset definition
 First get a Cohort definition set:
-```{r results='hide', error=FALSE, warning=FALSE, message=FALSE}
+```{r eval=FALSE}
 library(CohortGenerator)
 # A list of cohort IDs for use in this vignette
 cohortIds <- c(1778211, 1778212, 1778213)
@@ -63,7 +64,22 @@ cohortIds <- c(1778211, 1778212, 1778213)
 cohortDefinitionSet <- ROhdsiWebApi::exportCohortDefinitionSet(baseUrl = baseUrl,
                                                                cohortIds = cohortIds)
 ```
+```{r echo=FALSE, results='hide', error=FALSE, warning=FALSE, message=FALSE}
+# Hidden code block to load the cohortDefinitionSet from the package vs. trying to
+# download using ROhdsiWebApi to prevent errors when running GHA
+cohortDefinitionSet <- getCohortDefinitionSet(settingsFileName = "testdata/name/Cohorts.csv",
+                                              jsonFolder = "testdata/name/cohorts",
+                                              sqlFolder = "testdata/name/sql/sql_server",
+                                              cohortFileNameFormat = "%s",
+                                              cohortFileNameValue = c("cohortName"),
+                                              packageName = "CohortGenerator",
+                                              verbose = FALSE)
 
+cohortDefinitionSet$cohortId <- cohortDefinitionSet$cohortId + 1778210 # Match the cohort Ids from Atlas
+cohortIds <- cohortDefinitionSet$cohortId
+cohortDefinitionSet$atlasId <- cohortDefinitionSet$cohortId
+cohortDefinitionSet$logicDescription <- ""
+```
 A definition can include different subset operations - these are applied strictly in order:
 
 ```{r results='hide', error=FALSE, warning=FALSE, message=FALSE}
@@ -76,16 +92,21 @@ subsetDef <- createCohortSubsetDefinition(
     # here we are saying 'first subset to only those patients in cohort 1778213'
     createCohortSubset(id = 1001,
                        name = "Subset to patients in cohort 1778213",
-                       # Note that this can be set to any id - if the cohort is empty or doesn't exist this will not error
+                       # Note that this can be set to any id - if the 
+                       # cohort is empty or doesn't exist this will not error
                        cohortIds = 1778213,
                        cohortCombinationOperator = "any",
                        negate = FALSE,
-                       startWindow = createSubsetCohortWindow(startDay = -9999,
-                                                              endDay = 0,
-                                                              targetAnchor = "cohortStart"),
-                       endWindow = createSubsetCohortWindow(startDay = 0,
-                                                            endDay = 9999,
-                                                            targetAnchor = "cohortStart")),
+                       startWindow = createSubsetCohortWindow(
+                         startDay = -9999,
+                         endDay = 0,
+                         targetAnchor = "cohortStart"
+                       ),
+                       endWindow = createSubsetCohortWindow(
+                         startDay = 0,
+                         endDay = 9999,
+                         targetAnchor = "cohortStart")
+                       ),
 
     # Next, subset to only those with 365 days of prior observation
     createLimitSubset(id = 1002,
@@ -111,7 +132,7 @@ subsetOperations2[[3]] <-
                           ageMax = 64)
 
 subsetDef2 <- createCohortSubsetDefinition(
-  name = "Patients in cohort 1778213 with 365 days prior observation, aged 18 - 64",
+  name = "Patients in cohort 1778213 with 365 days prior obs, aged 18 - 64",
   definitionId = 2,
   subsetOperators = subsetOperations2)
 ```
@@ -124,7 +145,7 @@ for saving definition sets for re-use.
 cohortDefinitionSet <- cohortDefinitionSet |>
   addCohortSubsetDefinition(subsetDef)
 
-cohortDefinitionSet
+knitr::kable(cohortDefinitionSet[,names(cohortDefinitionSet)[which(!names(cohortDefinitionSet) %in% c("json", "sql"))]])
 ```
 We can also apply a subset definition to only a limted number of target cohorts as follows
 
@@ -132,7 +153,7 @@ We can also apply a subset definition to only a limted number of target cohorts 
 cohortDefinitionSet <- cohortDefinitionSet |>
   addCohortSubsetDefinition(subsetDef2, targetCohortIds = 1778212)
 
-cohortDefinitionSet
+knitr::kable(cohortDefinitionSet[,names(cohortDefinitionSet)[which(!names(cohortDefinitionSet) %in% c("json", "sql"))]])
 ```
 
 The `cohortDefinitionSet` data.frame now has some additional columns:
@@ -181,13 +202,15 @@ createCohortTables(connectionDetails = connectionDetails,
                    cohortDatabaseSchema = "main",
                    cohortTableNames = getCohortTableNames("my_cohort"))
 # ### As subsets are a big side effect we need to be clear what was generated and have good naming conventions
-generatedCohorts <- generateCohortSet(connectionDetails = connectionDetails,
-                                      cdmDatabaseSchema = "main",
-                                      cohortDatabaseSchema = "main",
-                                      cohortTableNames = getCohortTableNames("my_cohort"),
-                                      cohortDefinitionSet = cohortDefinitionSet,
-                                      incremental = TRUE,
-                                      incrementalFolder = file.path(someFolder, "RecordKeeping"))
+generatedCohorts <- generateCohortSet(
+  connectionDetails = connectionDetails,
+  cdmDatabaseSchema = "main",
+  cohortDatabaseSchema = "main",
+  cohortTableNames = getCohortTableNames("my_cohort"),
+  cohortDefinitionSet = cohortDefinitionSet,
+  incremental = TRUE,
+  incrementalFolder = file.path(someFolder, "RecordKeeping")
+)
 ```
 Cohort subset definitions can be run incrementally.
 In fact, if the base cohort definition changes for any reason, any subsets will automatically be re-executed when calling
@@ -208,7 +231,9 @@ loading is also achieved with `getCohortDefinitionSet`
 
 ```{r eval=FALSE}
 
-cohortDefinitionSet <- getCohortDefinitionSet(subsetJsonFolder = "<path_to_my_subset_definition>")
+cohortDefinitionSet <- getCohortDefinitionSet(
+  subsetJsonFolder = "<path_to_my_subset_definition>"
+)
 ```
 Any subset definitions should automatically be loaded and applied to the cohort definition set.
 

--- a/vignettes/GeneratingCohorts.Rmd
+++ b/vignettes/GeneratingCohorts.Rmd
@@ -39,13 +39,31 @@ This guide will provide examples of using the CohortGenerator package to generat
 We can create cohorts using [ATLAS](https://github.com/OHDSI/Atlas) and download them for generation in R. To do this, we will use the `ROhdsiWebApi` package to download some cohort definitions to R:
 
 
-```{r results='hide', error=FALSE, warning=FALSE, message=FALSE}
+```{r eval=FALSE}
 # A list of cohort IDs for use in this vignette
 cohortIds <- c(1778211,1778212,1778213)
 # Get the SQL/JSON for the cohorts
 cohortDefinitionSet <- ROhdsiWebApi::exportCohortDefinitionSet(baseUrl = baseUrl,
                                                                cohortIds = cohortIds)
 ```
+
+```{r echo=FALSE, results='hide', error=FALSE, warning=FALSE, message=FALSE}
+# Hidden code block to load the cohortDefinitionSet from the package vs. trying to
+# download using ROhdsiWebApi to prevent errors when running GHA
+cohortDefinitionSet <- getCohortDefinitionSet(settingsFileName = "testdata/name/Cohorts.csv",
+                                              jsonFolder = "testdata/name/cohorts",
+                                              sqlFolder = "testdata/name/sql/sql_server",
+                                              cohortFileNameFormat = "%s",
+                                              cohortFileNameValue = c("cohortName"),
+                                              packageName = "CohortGenerator",
+                                              verbose = FALSE)
+
+cohortDefinitionSet$cohortId <- cohortDefinitionSet$cohortId + 1778210 # Match the cohort Ids from Atlas
+cohortIds <- cohortDefinitionSet$cohortId
+cohortDefinitionSet$atlasId <- cohortDefinitionSet$cohortId
+cohortDefinitionSet$logicDescription <- ""
+```
+
 The code above connects to ATLAS' WebAPI, retrieves all of the `cohortDefinitions` and then filters them based on the name to produce the `cohortsForGeneration` dataframe. `cohortsForGeneration` contains the list of cohort IDs to use for calling the function `ROhdsiWebApi::exportCohortDefinitionSet` to download the set of cohort definitions into `cohortDefinitionSet`. The cohort definition set data frame has the following columns:
 
 ```{r}
@@ -66,9 +84,18 @@ The `cohortDefintionSet` contains all of the details about each cohort that we w
 
 ```{r, results='hide', error=FALSE, warning=FALSE, message=FALSE}
 saveCohortDefinitionSet(cohortDefinitionSet = cohortDefinitionSet,
-                        settingsFileName = file.path(packageRoot, "inst/settings/CohortsToCreate.csv"),
-                        jsonFolder = file.path(packageRoot, "inst/cohorts"),
-                        sqlFolder = file.path(packageRoot, "inst/sql/sql_server"))
+                        settingsFileName = file.path(
+                          packageRoot, 
+                          "inst/settings/CohortsToCreate.csv"
+                        ),
+                        jsonFolder = file.path(
+                          packageRoot, 
+                          "inst/cohorts"
+                        ),
+                        sqlFolder = file.path(
+                          packageRoot, 
+                          "inst/sql/sql_server"
+                        ))
 ```
 
 By default, saving the cohort definition set will create the files under a folder called `inst` which is where resources for a study package will live. Under `inst` the following folders and files are created:
@@ -80,9 +107,11 @@ By default, saving the cohort definition set will create the files under a folde
 Your study package can later re-construct the cohortDefinitionSet by reading in these resources using the `getCohortDefinitionSet` function.
 
 ```{r, results='hide', error=FALSE, warning=FALSE, message=FALSE}
-cohortDefinitionSet <- getCohortDefinitionSet(settingsFileName = file.path(packageRoot, "inst/settings/CohortsToCreate.csv"),
-                                              jsonFolder = file.path(packageRoot, "inst/cohorts"),
-                                              sqlFolder = file.path(packageRoot, "inst/sql/sql_server"))
+cohortDefinitionSet <- getCohortDefinitionSet(settingsFileName = file.path(
+  packageRoot, "inst/settings/CohortsToCreate.csv"),
+  jsonFolder = file.path(packageRoot, "inst/cohorts"),
+  sqlFolder = file.path(packageRoot, "inst/sql/sql_server")
+)
 ```
 
 
@@ -128,11 +157,13 @@ getCohortCounts(connectionDetails = connectionDetails,
 
 Cohorts defined in ATLAS may define one or more inclusion criteria as part of the cohort's logic. As part of cohort generation, we may want to capture these cohort statistics for use in other packages. For example, [CohortDiagnostics](https://ohdsi.github.io/CohortDiagnostics) has functionality that allows for review of inclusion rule statistics to understand how these rules may materialize between data sources. Here we will review how to generate cohorts with inclusion rule statistics and how to export these results for use by downstream packages such as CohortDiagnostics. Building on our basic example, let's export the cohorts from WebAPI but this time indicate that we'd like to also include the code that `generatesStats`:
 
-```{r, results='hide', error=FALSE, warning=FALSE, message=FALSE}
+```{r, eval=FALSE}
 # Get the cohorts and include the code to generate inclusion rule stats
-cohortDefinitionSet <- ROhdsiWebApi::exportCohortDefinitionSet(baseUrl = baseUrl,
-                                                               cohortIds = cohortIds,
-                                                               generateStats = TRUE)
+cohortDefinitionSet <- ROhdsiWebApi::exportCohortDefinitionSet(
+  baseUrl = baseUrl,
+  cohortIds = cohortIds,
+  generateStats = TRUE
+)
 ```
 
 Next we'll create the tables to store the cohort and the cohort statistics. Then we can generate the cohorts.
@@ -160,15 +191,19 @@ generateCohortSet(connectionDetails= connectionDetails,
 At this stage, your cohorts are generated and any cohort statistics are available in the cohort statistics tables. The next step is to export the results to the file system which is done using the code below:
 
 ```{r, results='hide', error=FALSE, warning=FALSE, message=FALSE}
-insertInclusionRuleNames(connectionDetails = connectionDetails,
-                         cohortDefinitionSet = cohortDefinitionSet,
-                         cohortDatabaseSchema = "main",
-                         cohortInclusionTable = cohortTableNames$cohortInclusionTable)
+insertInclusionRuleNames(
+  connectionDetails = connectionDetails,
+  cohortDefinitionSet = cohortDefinitionSet,
+  cohortDatabaseSchema = "main",
+  cohortInclusionTable = cohortTableNames$cohortInclusionTable
+)
 
-exportCohortStatsTables(connectionDetails = connectionDetails,
-                        cohortDatabaseSchema = "main",
-                        cohortTableNames = cohortTableNames,
-                        cohortStatisticsFolder = file.path(someFolder, "InclusionStats"))
+exportCohortStatsTables(
+  connectionDetails = connectionDetails,
+  cohortDatabaseSchema = "main",
+  cohortTableNames = cohortTableNames,
+  cohortStatisticsFolder = file.path(someFolder, "InclusionStats")
+)
 ```
 
 The code above performs two steps. First, we insert the inclusion rule names from the Circe expressions in the `cohortDefinitionSet`. This is important since these names are not automatically inserted into the database when generating the cohorts. Second, we export the cohort statistics to the file system which will write comma separated value (CSV) files per cohort statistic table in the `InclusionStats` folder.


### PR DESCRIPTION
Removes the evaluation of code blocks in the vignette to prevent issues if the public OHDSI WebAPI is unavailable as mentioned in #70. 

Also includes small updates to formatting in the vigettes to allow code blocks to fit in the proper margins and for displaying the `cohortDefinitionSet` output in a formatted table without the JSON/SQL which was unreadable.