### PR TITLE
Integer64 fix for CohortDefinitionSet

### DIFF
--- a/inst/cohortDefinitionSetSpecificationDescription.csv
+++ b/inst/cohortDefinitionSetSpecificationDescription.csv
@@ -1,5 +1,5 @@
 column_name,description,data_type
-cohortId,The identifier for the cohort in the cohort definition set.,integer64
+cohortId,The identifier for the cohort in the cohort definition set.,numeric
 cohortName,The name of the cohort in the cohort definition set.,character
 sql,The SQL code used to construct the cohort,character
 json,The optional Circe compliant JSON representation of the cohort definition.,character


### PR DESCRIPTION
This will resolve the issue temporarily but I don't think a csv file is appropriate for the type checking behaviour here as there is more complexity than this. We can't use the integer64 method either.