### PR TITLE
Update stats query to address Oracle issue. Expand platform tests

### DIFF
--- a/R/CohortStats.R
+++ b/R/CohortStats.R
@@ -153,7 +153,7 @@ getStatsTable <- function(connectionDetails,
   }
 
   ParallelLogger::logInfo("- Fetching data from ", table)
-  sql <- "SELECT {@database_id != ''}?{CAST('@database_id' as VARCHAR(255)) as database_id,} * FROM @cohort_database_schema.@table"
+  sql <- "SELECT {@database_id != ''}?{CAST('@database_id' as VARCHAR(255)) as database_id,} t.* FROM @cohort_database_schema.@table t"
   data <- DatabaseConnector::renderTranslateQuerySql(
     sql = sql,
     connection = connection,

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -134,6 +134,7 @@ getPlatformConnectionDetails <- function(dbmsPlatform) {
   }
 
   return(list(
+    dbmsPlatform = dbmsPlatform,
     connectionDetails = connectionDetails,
     cohortDatabaseSchema = cohortDatabaseSchema,
     cohortTable = cohortTable,

--- a/tests/testthat/test-dbms-platforms.R
+++ b/tests/testthat/test-dbms-platforms.R
@@ -61,7 +61,6 @@ testPlatform <- function(dbmsDetails) {
     snakeCaseToCamelCase = FALSE,
     fileNamesInSnakeCase = TRUE,
     incremental = TRUE,
-    incrementalFolder = file.path(outputFolder, "RecordKeeping", dbmsDetails$connectionDetails$dbms),
     databaseId = dbmsDetails$dbmsPlatform
   )
   

--- a/tests/testthat/test-dbms-platforms.R
+++ b/tests/testthat/test-dbms-platforms.R
@@ -34,7 +34,37 @@ testPlatform <- function(dbmsDetails) {
     incrementalFolder = file.path(outputFolder, "RecordKeeping", dbmsDetails$connectionDetails$dbms)
   )
   expect_equal(nrow(cohortsGenerated), nrow(cohortsWithStats))
-
+  
+  # Get the cohort counts
+  cohortCounts <- getCohortCounts(
+    connectionDetails = dbmsDetails$connectionDetails,
+    cohortDatabaseSchema = dbmsDetails$cohortDatabaseSchema,
+    cohortTable = cohortTableNames$cohortTable,
+    databaseId = dbmsDetails$dbmsPlatform,
+    cohortDefinitionSet = cohortsWithStats
+  )  
+  expect_equal(nrow(cohortsGenerated), nrow(cohortCounts))
+  
+  # Insert the inclusion rule names before exporting the stats tables
+  insertInclusionRuleNames(
+    connectionDetails = dbmsDetails$connectionDetails,
+    cohortDefinitionSet = cohortsWithStats,
+    cohortDatabaseSchema = dbmsDetails$cohortDatabaseSchema,
+    cohortInclusionTable = cohortTableNames$cohortInclusionTable
+  )
+  
+  exportCohortStatsTables(
+    connectionDetails = dbmsDetails$connectionDetails,
+    cohortTableNames = cohortTableNames,
+    cohortDatabaseSchema = dbmsDetails$cohortDatabaseSchema,
+    cohortStatisticsFolder = file.path(outputFolder, dbmsDetails$dbmsPlatform),
+    snakeCaseToCamelCase = FALSE,
+    fileNamesInSnakeCase = TRUE,
+    incremental = TRUE,
+    incrementalFolder = file.path(outputFolder, "RecordKeeping", dbmsDetails$connectionDetails$dbms),
+    databaseId = dbmsDetails$dbmsPlatform
+  )
+  
   subsetOperations <- list(
     createCohortSubset(
       cohortIds = 2,


### PR DESCRIPTION
Fixes #96 and adds test to explicitly test the inclusion rule stats export.