### PR TITLE
Ensure database_id is applied to all returned cohort counts

### DIFF
--- a/R/CohortCount.R
+++ b/R/CohortCount.R
@@ -60,8 +60,7 @@ getCohortCounts <- function(connectionDetails = NULL,
     sql = sql,
     cohort_database_schema = cohortDatabaseSchema,
     cohort_table = cohortTable,
-    cohort_ids = cohortIds,
-    database_id = ifelse(test = is.null(databaseId), yes = "", no = databaseId)
+    cohort_ids = cohortIds
   )
   sql <- SqlRender::translate(sql = sql, targetDialect = connection@dbms)
   tablesInServer <- tolower(DatabaseConnector::getTableNames(conn = connection, databaseSchema = cohortDatabaseSchema))
@@ -87,6 +86,9 @@ getCohortCounts <- function(connectionDetails = NULL,
         cohortEntries = ifelse(is.na(cohortEntries), 0L, cohortEntries),
         cohortSubjects = ifelse(is.na(cohortSubjects), 0L, cohortSubjects)
       )
+    }
+    if (!is.null(databaseId)) {
+      counts$databaseId <- databaseId
     }
     return(counts)
   } else {

--- a/inst/sql/sql_server/CohortCounts.sql
+++ b/inst/sql/sql_server/CohortCounts.sql
@@ -1,5 +1,4 @@
 SELECT
-  {@database_id != ''}?{CAST('@database_id' as VARCHAR(255)) as database_id,}
   cohort_definition_id AS cohort_id,
   COUNT(*) AS cohort_entries,
   COUNT(DISTINCT subject_id) AS cohort_subjects

--- a/tests/testthat/test-CohortCount.R
+++ b/tests/testthat/test-CohortCount.R
@@ -111,12 +111,14 @@ test_that("Call getCohortCounts with a cohortDefinitionSet returns 0 counts for 
     cohortDatabaseSchema = "main",
     cohortTable = "cohort",
     cohortIds = c(1, 2, 100),
-    cohortDefinitionSet = cohortDefinitionSet
+    cohortDefinitionSet = cohortDefinitionSet,
+    databaseId = 999
   )
 
   expect_true(nrow(testCohortCounts) == 3)
   expect_true(testCohortCounts[testCohortCounts$cohortId == 100, "cohortEntries"] == 0)
   expect_true(testCohortCounts[testCohortCounts$cohortId == 100, "cohortSubjects"] == 0)
+  expect_true(all(testCohortCounts$databaseId == 999))
 })
 
 test_that("Call getCohortCounts with no cohortId specified and cohortDefinitionSet returns 0 counts for cohortId not in cohort table", {


### PR DESCRIPTION
Cohort counts == 0 were missing the database identifier.