### PR TITLE
Revise to use numeric for nco cohorts

### DIFF
--- a/R/CohortDefinitionSet.R
+++ b/R/CohortDefinitionSet.R
@@ -513,11 +513,7 @@ checkSettingsColumns <- function(columnNames, settingsFileName = NULL) {
   for (i in 1:nrow(specifications)) {
     colName <- specifications$columnName[i]
     dataType <- specifications$dataType[i]
-    if (dataType == "integer64") {
-      df <- df %>% dplyr::mutate(!!colName := do.call(what = bit64::as.integer64, args = list()))
-    } else {
-      df <- df %>% dplyr::mutate(!!colName := do.call(what = dataType, args = list()))
-    }
+    df <- df %>% dplyr::mutate(!!colName := do.call(what = dataType, args = list()))
   }
   invisible(df)
 }

--- a/inst/negativeControlOutcomeCohortSetSpecificationDescription.csv
+++ b/inst/negativeControlOutcomeCohortSetSpecificationDescription.csv
@@ -1,4 +1,4 @@
 column_name,description,data_type
-cohortId,The identifier for the cohort in the negative control outcome cohort set.,integer64
+cohortId,The identifier for the cohort in the negative control outcome cohort set.,numeric
 cohortName,The name of the cohort in the negative control outcome cohort set.,character
-outcomeConceptId,The concept_id used to construct the negative control cohort. This concept_id must be in the condition domain,integer64
+outcomeConceptId,The concept_id used to construct the negative control cohort. This concept_id must be in the condition domain,numeric


### PR DESCRIPTION
Aims to remove `bit64` references per #152.