### PR TITLE
Expose col_types from readr

### DIFF
--- a/R/CsvHelper.R
+++ b/R/CsvHelper.R
@@ -27,13 +27,43 @@
 #' @param file  The .csv file to read.
 #' @param warnOnCaseMismatch  When TRUE, raise a warning if column headings
 #' in the .csv are not in snake_case format
+#' 
+#' @param colTypes Corresponds to the `col_types` in the `readr::read_csv` function.
+#'   One of `NULL`, a [readr::cols()] specification, or
+#'   a string. See `vignette("readr")` for more details.
 #'
+#'    If `NULL`, all column types will be inferred from `guess_max` rows of the
+#'    input, interspersed throughout the file. This is convenient (and fast),
+#'    but not robust. If the guessed types are wrong, you'll need to increase
+#'    `guess_max` or supply the correct types yourself.
+#'
+#'    Column specifications created by [list()] or [cols()] must contain
+#'    one column specification for each column. 
+#'
+#'    Alternatively, you can use a compact string representation where each
+#'    character represents one column:
+#'    - c = character
+#'    - i = integer
+#'    - n = number
+#'    - d = double
+#'    - l = logical
+#'    - f = factor
+#'    - D = date
+#'    - T = date time
+#'    - t = time
+#'    - ? = guess
+#'    - _ or - = skip
+#'
+#'    By default, reading a file without a column specification will print a
+#'    message showing what `readr` guessed they were. To remove this message,
+#'    set `show_col_types = FALSE` or set `options(readr.show_col_types = FALSE)`.
+#'  
 #' @return
 #' A tibble with the .csv contents
 #'
 #' @export
-readCsv <- function(file, warnOnCaseMismatch = TRUE) {
-  fileContents <- .readCsv(file = file)
+readCsv <- function(file, warnOnCaseMismatch = TRUE, colTypes = readr::cols()) {
+  fileContents <- .readCsv(file = file, colTypes = colTypes)
   columnNames <- colnames(fileContents)
   columnNamesInSnakeCaseFormat <- isSnakeCase(columnNames)
   if (!all(columnNamesInSnakeCaseFormat) && warnOnCaseMismatch) {
@@ -58,10 +88,10 @@ readCsv <- function(file, warnOnCaseMismatch = TRUE) {
 #'
 #' @noRd
 #' @keywords internal
-.readCsv <- function(file) {
+.readCsv <- function(file, colTypes = readr::cols()) {
   invisible(readr::read_csv(
     file = file,
-    col_types = readr::cols(),
+    col_types = colTypes,
     lazy = FALSE
   ))
 }

--- a/man/readCsv.Rd
+++ b/man/readCsv.Rd
@@ -4,13 +4,43 @@
 \alias{readCsv}
 \title{Used to read a .csv file}
 \usage{
-readCsv(file, warnOnCaseMismatch = TRUE)
+readCsv(file, warnOnCaseMismatch = TRUE, colTypes = readr::cols())
 }
 \arguments{
 \item{file}{The .csv file to read.}
 
 \item{warnOnCaseMismatch}{When TRUE, raise a warning if column headings
 in the .csv are not in snake_case format}
+
+\item{colTypes}{Corresponds to the `col_types` in the `readr::read_csv` function.
+  One of `NULL`, a [readr::cols()] specification, or
+  a string. See `vignette("readr")` for more details.
+
+   If `NULL`, all column types will be inferred from `guess_max` rows of the
+   input, interspersed throughout the file. This is convenient (and fast),
+   but not robust. If the guessed types are wrong, you'll need to increase
+   `guess_max` or supply the correct types yourself.
+
+   Column specifications created by [list()] or [cols()] must contain
+   one column specification for each column. 
+
+   Alternatively, you can use a compact string representation where each
+   character represents one column:
+   - c = character
+   - i = integer
+   - n = number
+   - d = double
+   - l = logical
+   - f = factor
+   - D = date
+   - T = date time
+   - t = time
+   - ? = guess
+   - _ or - = skip
+
+   By default, reading a file without a column specification will print a
+   message showing what `readr` guessed they were. To remove this message,
+   set `show_col_types = FALSE` or set `options(readr.show_col_types = FALSE)`.}
 }
 \value{
 A tibble with the .csv contents


### PR DESCRIPTION
Allows for explicit data type to column mapping to avoid issues as described in #59. Here is a reprex for the code in this branch:

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
```

``` r
df <- data.frame(database_id = "optum",
                 cohort_id = 27,
                 rule_sequence = 0,
                 name = "No COPD piror",
                 description = "")
df <- rbind(df, data.frame(database_id = "optum",
                           cohort_id = 28,
                           rule_sequence = 0,
                           name = "No piror asthma",
                           description = ""))
df
#>   database_id cohort_id rule_sequence            name description
#> 1       optum        27             0   No COPD piror            
#> 2       optum        28             0 No piror asthma
```

``` r

tf <- tempfile(fileext = ".csv")
CohortGenerator::saveIncremental(data = df,
                                 fileName = tf,
                                 database_id = df$database_id,
                                 cohort_id = df$cohort_id)

# readr guesses decription is logical
df2 <- CohortGenerator::readCsv(file = tf)
df2
#> # A tibble: 2 x 5
#>   databaseId cohortId ruleSequence name            description
#>   <chr>         <dbl>        <dbl> <chr>           <lgl>      
#> 1 optum            27            0 No COPD piror   NA         
#> 2 optum            28            0 No piror asthma NA
```

``` r

# explictly declare the column types
df3 <- CohortGenerator::readCsv(
  file = tf,
  colTypes = list('c', 'd', 'd', 'c', 'c')
)
df3
#> # A tibble: 2 x 5
#>   databaseId cohortId ruleSequence name            description
#>   <chr>         <dbl>        <dbl> <chr>           <chr>      
#> 1 optum            27            0 No COPD piror   <NA>       
#> 2 optum            28            0 No piror asthma <NA>
```

``` r

# do it again for testing join conditions
df4 <- CohortGenerator::readCsv(
  file = tf,
  colTypes = list('c', 'd', 'd', 'c', 'c')
)

# test joining data frames with the same description data type
df5 <- df3 %>% inner_join(df4)
#> Joining with `by = join_by(databaseId, cohortId, ruleSequence, name,
#> description)`
```

``` r
df5
#> # A tibble: 2 x 5
#>   databaseId cohortId ruleSequence name            description
#>   <chr>         <dbl>        <dbl> <chr>           <chr>      
#> 1 optum            27            0 No COPD piror   <NA>       
#> 2 optum            28            0 No piror asthma <NA>
```

``` r

# test joining data frames with different description data type
df6 <- df3 %>% inner_join(df2)
#> Joining with `by = join_by(databaseId, cohortId, ruleSequence, name,
#> description)`
```

``` r
df6
#> # A tibble: 2 x 5
#>   databaseId cohortId ruleSequence name            description
#>   <chr>         <dbl>        <dbl> <chr>           <chr>      
#> 1 optum            27            0 No COPD piror   <NA>       
#> 2 optum            28            0 No piror asthma <NA>
```

``` r

# test joining data frames with different description data type (order doesn't matter)
df7 <- df2 %>% inner_join(df3)
#> Joining with `by = join_by(databaseId, cohortId, ruleSequence, name,
#> description)`
```

``` r
df7
#> # A tibble: 2 x 5
#>   databaseId cohortId ruleSequence name            description
#>   <chr>         <dbl>        <dbl> <chr>           <chr>      
#> 1 optum            27            0 No COPD piror   <NA>       
#> 2 optum            28            0 No piror asthma <NA>
```

<sup>Created on 2024-06-05 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
