### PR TITLE
runCohortGenerator bug fix & remove R4.2.3 tests

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -20,9 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '4.2.3', rtools: '42', rspm: "https://cloud.r-project.org"}
-          - {os: macOS-latest, r: '4.2.3', rtools: '42', rspm: "https://cloud.r-project.org"}
-          - {os: ubuntu-20.04, r: '4.2.3', rtools: '42', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: windows-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
           - {os: macOS-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
           - {os: ubuntu-20.04, r: 'release', rtools: '', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}

--- a/R/CohortCount.R
+++ b/R/CohortCount.R
@@ -77,7 +77,7 @@ getCohortCounts <- function(connectionDetails = NULL,
       }
       counts <- merge(
         x = counts,
-        y = cohortDefinitionSet[cohortDefinitionSet$cohortId %in% cohortIds, ],
+        y = cohortDefinitionSet[cohortDefinitionSet$cohortId %in% cohortIds, , drop = FALSE],
         by = "cohortId",
         all.y = TRUE
       )

--- a/R/RunCohortGeneration.R
+++ b/R/RunCohortGeneration.R
@@ -288,7 +288,7 @@ generateAndExportNegativeControls <- function(connection,
       cohortDatabaseSchema = cohortDatabaseSchema,
       cohortTable = cohortTableNames$cohortTable,
       databaseId = databaseId,
-      cohortDefinitionSet = negativeControlOutcomeCohortSet[,c("cohortId")]
+      cohortDefinitionSet = negativeControlOutcomeCohortSet[,c("cohortId"), drop = FALSE]
     )
   }
   


### PR DESCRIPTION
Preserves the `data.frame` for the cohortDefinitionSet when selecting a single column. Also removes R4.2.3 specific unit tests.