### PR TITLE
Remove warning around finalize

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
   readr (>= 2.1.0),
   rlang,
   jsonlite,
-  ResultModelManager,
+  ResultModelManager (>= 0.6.0),
   SqlRender (>= 1.11.1),
   stringi (>= 1.7.6),
   tibble

--- a/R/ResultsDataModel.R
+++ b/R/ResultsDataModel.R
@@ -121,7 +121,7 @@ migrateDataModel <- function(connectionDetails, databaseSchema, tablePrefix = ""
     tablePrefix = tablePrefix
   )
   migrator$executeMigrations()
-  migrator$finalize()
+  migrator$closeConnection()
 }
 
 #' Get database migrations instance


### PR DESCRIPTION
This warning is there because R6 plans to make finalize calls private in a future version.