### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
-          #- {os: macOS-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
-          #- {os: ubuntu-22.04, r: 'release', rtools: ''}
+          - {os: macOS-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
+          - {os: ubuntu-22.04, r: 'release', rtools: ''}
     env:
       GITHUB_PAT: ${{ secrets.GH_TOKEN }}
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
-          - {os: macOS-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
-          - {os: ubuntu-22.04, r: 'release', rtools: ''}
+          #- {os: macOS-latest, r: 'release', rtools: '', rspm: "https://cloud.r-project.org"}
+          #- {os: ubuntu-22.04, r: 'release', rtools: ''}
     env:
       GITHUB_PAT: ${{ secrets.GH_TOKEN }}
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -103,7 +103,7 @@ jobs:
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "22.04"))')
           
       - name: Setup Java
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' || runner.os == 'Windows'
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,5 @@
-dbmsPlatforms <- c("bigquery", "oracle", "postgresql", "redshift", "spark", "sql server") # DISABLE "snowflake" test for now
+#dbmsPlatforms <- c("bigquery", "oracle", "postgresql", "redshift", "spark", "sql server") # DISABLE "snowflake" test for now
+dbmsPlatforms <- c("snowflake")
 connectionDetails <- Eunomia::getEunomiaConnectionDetails()
 outputFolder <- tempfile()
 dir.create(outputFolder)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,4 @@
-#dbmsPlatforms <- c("bigquery", "oracle", "postgresql", "redshift", "spark", "sql server") # DISABLE "snowflake" test for now
-dbmsPlatforms <- c("snowflake")
+dbmsPlatforms <- c("bigquery", "oracle", "postgresql", "redshift", "snowflake", "spark", "sql server")
 connectionDetails <- Eunomia::getEunomiaConnectionDetails()
 outputFolder <- tempfile()
 dir.create(outputFolder)


### PR DESCRIPTION
Ensure Java 8 is installed for Windows otherwise DataBricks errors with `java.sql.SQLException: [Databricks][JDBCDriver](500540) Error caught in BackgroundFetcher. Foreground thread ID: 1. Background thread ID: 132. Error caught: null.`

Re-enable Snowflake tests which were also fixed via the Java 8 install for Windows.