### PR TITLE
Fix issue with unboxing nulls

### DIFF
--- a/R/Export.R
+++ b/R/Export.R
@@ -326,6 +326,10 @@ enforceMinCellValue <- function(data, fieldName, minValues, silent = FALSE) {
 #' Only use on vectors of length 1 or 0 or it will throw an error (as unbox does)
 #' @noRd
 safeUnbox <- function(x) {
+  if (is.factor(x)) {
+    x <- as.character(x)
+  }
+  
   if (length(x) == 0)
     x <- NULL
 

--- a/R/Export.R
+++ b/R/Export.R
@@ -320,3 +320,13 @@ enforceMinCellValue <- function(data, fieldName, minValues, silent = FALSE) {
   }
   return(data)
 }
+
+#' Safely unbox values with jsonlite::unbox
+#' where values are of length 0 they are converted to NULL
+#' @noRd
+safeUnbox <- function(x) {
+  if (length(x) == 0)
+    x <- NULL
+
+  return(jsonlite::unbox(x))
+}

--- a/R/Export.R
+++ b/R/Export.R
@@ -323,6 +323,7 @@ enforceMinCellValue <- function(data, fieldName, minValues, silent = FALSE) {
 
 #' Safely unbox values with jsonlite::unbox
 #' where values are of length 0 they are converted to NULL
+#' Only use on vectors of length 1 or 0 or it will throw an error (as unbox does)
 #' @noRd
 safeUnbox <- function(x) {
   if (length(x) == 0)

--- a/R/SubsetDefinitions.R
+++ b/R/SubsetDefinitions.R
@@ -76,16 +76,16 @@ CohortSubsetDefinition <- R6::R6Class(
     #' @description List representation of object
     toList = function() {
       list(
-        name = jsonlite::unbox(self$name),
-        definitionId = jsonlite::unbox(self$definitionId),
+        name = safeUnbox(self$name),
+        definitionId = safeUnbox(self$definitionId),
         # Note - when there is a base definition that includes multiple calls to the same subset this should be replaced
         subsetOperators = lapply(self$subsetOperators, function(operator) {
           operator$toList()
         }),
-        packageVersion = jsonlite::unbox(as.character(utils::packageVersion("CohortGenerator"))),
-        identifierExpression = jsonlite::unbox(as.character(private$.identifierExpression)),
-        operatorNameConcatString = jsonlite::unbox(as.character(private$.operatorNameConcatString)),
-        subsetCohortNameTemplate = jsonlite::unbox(as.character(private$.subsetCohortNameTemplate))
+        packageVersion = safeUnbox(as.character(utils::packageVersion("CohortGenerator"))),
+        identifierExpression = safeUnbox(as.character(private$.identifierExpression)),
+        operatorNameConcatString = safeUnbox(as.character(private$.operatorNameConcatString)),
+        subsetCohortNameTemplate = safeUnbox(as.character(private$.subsetCohortNameTemplate))
       )
     },
     #' to JSON

--- a/R/SubsetRecipeFunctions.R
+++ b/R/SubsetRecipeFunctions.R
@@ -109,12 +109,19 @@ addIndicationSubsetDefinition <- function(cohortDefinitionSet,
   checkmate::assertTRUE(all(indicationCohortIds %in% cohortDefinitionSet$cohortId))
 
   subsetOperators <- list()
+
+  if (!is.null(studyEndDate))
+    studyEndDate <- as.Date(studyEndDate, "%Y%m%d")
+
+  if (!is.null(studyStartDate))
+    studyStartDate <- as.Date(studyStartDate, "%Y%m%d")
+
   subsetOperators[[length(subsetOperators) + 1]] <- createLimitSubsetOperator(
     priorTime = requiredPriorObservationTime,
     followUpTime = requiredFollowUpTime,
     limitTo = "firstEver",
-    calendarStartDate = as.Date(studyStartDate, "%Y%m%d"),
-    calendarEndDate = as.Date(studyEndDate, "%Y%m%d")
+    calendarStartDate = studyStartDate,
+    calendarEndDate = studyEndDate
   )
 
   if (any(!is.null(c(genderConceptIds, ageMin, ageMax)))) {

--- a/R/Subsets.R
+++ b/R/Subsets.R
@@ -53,20 +53,20 @@ SubsetCohortWindow <- R6::R6Class(
     toList = function() {
       objRepr <- list()
       if (length(private$.startDay)) {
-        objRepr$startDay <- jsonlite::unbox(private$.startDay)
+        objRepr$startDay <- safeUnbox(private$.startDay)
       }
       if (length(private$.endDay)) {
-        objRepr$endDay <- jsonlite::unbox(private$.endDay)
+        objRepr$endDay <- safeUnbox(private$.endDay)
       }
       if (length(private$.targetAnchor)) {
-        objRepr$targetAnchor <- jsonlite::unbox(private$.targetAnchor)
+        objRepr$targetAnchor <- safeUnbox(private$.targetAnchor)
       }
 
       if (length(private$.subsetAnchor)) {
-        objRepr$subsetAnchor <- jsonlite::unbox(private$.subsetAnchor)
+        objRepr$subsetAnchor <- safeUnbox(private$.subsetAnchor)
       }
       if (length(private$.negate)) {
-        objRepr$negate <- jsonlite::unbox(private$.negate)
+        objRepr$negate <- safeUnbox(private$.negate)
       }
       objRepr
     },
@@ -270,8 +270,8 @@ SubsetOperator <- R6::R6Class(
     #' @description convert to List representation
     toList = function() {
       repr <- list(
-        name = jsonlite::unbox(self$name),
-        subsetType = jsonlite::unbox(self$classname())
+        name = safeUnbox(self$name),
+        subsetType = safeUnbox(self$classname())
       )
       return(repr)
     },
@@ -357,8 +357,8 @@ CohortSubsetOperator <- R6::R6Class(
     toList = function() {
       objRepr <- super$toList()
       objRepr$cohortIds <- private$.cohortIds
-      objRepr$cohortCombinationOperator <- jsonlite::unbox(private$.cohortCombinationOperator)
-      objRepr$negate <- jsonlite::unbox(private$.negate)
+      objRepr$cohortCombinationOperator <- safeUnbox(private$.cohortCombinationOperator)
+      objRepr$negate <- safeUnbox(private$.negate)
       objRepr$windows <- lapply(private$.windows, function(x) {
         x$toList()
       })
@@ -526,10 +526,10 @@ DemographicSubsetOperator <- R6::R6Class(
     toList = function() {
       objRepr <- super$toList()
       if (length(private$.ageMin)) {
-        objRepr$ageMin <- jsonlite::unbox(private$.ageMin)
+        objRepr$ageMin <- safeUnbox(private$.ageMin)
       }
       if (length(private$.ageMax)) {
-        objRepr$ageMax <- jsonlite::unbox(private$.ageMax)
+        objRepr$ageMax <- safeUnbox(private$.ageMax)
       }
       if (!is.null(private$.gender)) {
         objRepr$gender <- private$.gender
@@ -839,13 +839,13 @@ LimitSubsetOperator <- R6::R6Class(
     #' @description List representation of object
     toList = function() {
       objRef <- super$toList()
-      objRef$priorTime <- jsonlite::unbox(private$.priorTime)
-      objRef$followUpTime <- jsonlite::unbox(private$.followUpTime)
-      objRef$minimumCohortDuration <- jsonlite::unbox(private$.minimumCohortDuration)
-      objRef$maximumCohortDuration <- jsonlite::unbox(private$.maximumCohortDuration)
-      objRef$limitTo <- jsonlite::unbox(private$.limitTo)
-      objRef$calendarStartDate <- jsonlite::unbox(private$.calendarStartDate)
-      objRef$calendarEndDate <- jsonlite::unbox(private$.calendarEndDate)
+      objRef$priorTime <- safeUnbox(private$.priorTime)
+      objRef$followUpTime <- safeUnbox(private$.followUpTime)
+      objRef$minimumCohortDuration <- safeUnbox(private$.minimumCohortDuration)
+      objRef$maximumCohortDuration <- safeUnbox(private$.maximumCohortDuration)
+      objRef$limitTo <- safeUnbox(private$.limitTo)
+      objRef$calendarStartDate <- safeUnbox(private$.calendarStartDate)
+      objRef$calendarEndDate <- safeUnbox(private$.calendarEndDate)
 
       objRef
     }

--- a/tests/testthat/test-Export.R
+++ b/tests/testthat/test-Export.R
@@ -475,3 +475,39 @@ test_that("export template definitions functions", {
   cs <- read.csv(file.path(outputFolder, "cg_cohort_template_link.csv"))
   checkmate::expect_data_frame(cs, nrows = 1)
 })
+
+
+test_that("empty vector becomes NULL", {
+  expect_equal(
+    jsonlite::toJSON(safeUnbox(character(0))),
+    "null"
+  )
+
+  expect_equal(
+    jsonlite::toJSON(safeUnbox(numeric(0))),
+    "null"
+  )
+})
+
+test_that("scalar values are unboxed", {
+  expect_equal(jsonlite::toJSON(safeUnbox("a")), "\"a\"")
+  expect_equal(jsonlite::toJSON(safeUnbox(42)), "42")
+  expect_equal(jsonlite::toJSON(safeUnbox(TRUE)), "true")
+})
+
+test_that("NA values serialize as null", {
+  expect_equal(jsonlite::toJSON(safeUnbox(NA)), "null")
+})
+
+test_that("multi-length vectors throw an error from unbox", {
+  expect_error(safeUnbox(c(1, 2)), "length.*1")
+})
+
+test_that("factors are coerced to character before unboxing", {
+  f <- factor("level1")
+  expect_equal(jsonlite::toJSON(safeUnbox(f)), "\"level1\"")
+})
+
+test_that("NULL input stays NULL", {
+  expect_equal(jsonlite::toJSON(safeUnbox(NULL)), "null")
+})

--- a/tests/testthat/test-Export.R
+++ b/tests/testthat/test-Export.R
@@ -478,36 +478,34 @@ test_that("export template definitions functions", {
 
 
 test_that("empty vector becomes NULL", {
-  expect_equal(
-    jsonlite::toJSON(safeUnbox(character(0))),
-    "null"
+  expect_null(
+    safeUnbox(character(0))
   )
 
-  expect_equal(
-    jsonlite::toJSON(safeUnbox(numeric(0))),
-    "null"
+  expect_null(
+    safeUnbox(numeric(0))
   )
 })
 
 test_that("scalar values are unboxed", {
-  expect_equal(jsonlite::toJSON(safeUnbox("a")), "\"a\"")
-  expect_equal(jsonlite::toJSON(safeUnbox(42)), "42")
-  expect_equal(jsonlite::toJSON(safeUnbox(TRUE)), "true")
+  expect_equal(safeUnbox("a"), jsonlite::unbox("a"))
+  expect_equal(safeUnbox(42), jsonlite::unbox(42))
+  expect_equal(safeUnbox(TRUE), jsonlite::unbox(TRUE))
 })
 
 test_that("NA values serialize as null", {
-  expect_equal(jsonlite::toJSON(safeUnbox(NA)), "null")
+  expect_equal(safeUnbox(NA), jsonlite::unbox(NA))
 })
 
 test_that("multi-length vectors throw an error from unbox", {
-  expect_error(safeUnbox(c(1, 2)), "length.*1")
+  expect_error(safeUnbox(c(1, 2)), "length.*2")
 })
 
 test_that("factors are coerced to character before unboxing", {
   f <- factor("level1")
-  expect_equal(jsonlite::toJSON(safeUnbox(f)), "\"level1\"")
+  expect_equal(safeUnbox(f), jsonlite::unbox("level1"))
 })
 
 test_that("NULL input stays NULL", {
-  expect_equal(jsonlite::toJSON(safeUnbox(NULL)), "null")
+  expect_equal(safeUnbox(NULL), jsonlite::unbox(NULL))
 })


### PR DESCRIPTION
So this is an issue with `jsonlite::unbox` in my opinion.

When you do unbox on a vector of length 0 it throws an error

```
> jsonlite::unbox(integer())
Error: Tried to unbox a vector of length 0

# This can happen because of a type conversion from NULL
> jsonlite::unbox(as.Date(NULL, "%Y%m%d")) 
Error: Tried to unbox a vector of length 0
```

But this is not a problem if you pass in `NULL` (which is of length 0)

> jsonlite::unbox(NULL)
NULL

Its likely fine to save values as null so this PR does the conversion.
We should have runtime checks for situations where values can't be nullable as this is R and its required.