### PR TITLE
Fix negate when using cohort subset operator

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CohortGenerator
 Type: Package
 Title: Cohort Generation for the OMOP Common Data Model
-Version: 1.0.1
+Version: 1.0.2
 Date: 2025-11-17
 Authors@R: c(
   person("Anthony", "Sena", email = "sena@ohdsi.org", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+CohortGenerator 1.0.2
+=====================
+
+Bug Fixes
+- Fix bug where `negate` parameter of `createCohortSubsetOperator` was not passed properly to the SQL statement
+
 CohortGenerator 1.0.1
 =====================
 

--- a/R/SubsetQueryBuilders.R
+++ b/R/SubsetQueryBuilders.R
@@ -79,7 +79,7 @@ CohortSubsetQb <- R6::R6Class(
       sql <- SqlRender::render(sql,
         target_table = targetTable,
         output_table = self$getTableObjectId(),
-        negate = private$operator$negate,
+        negate = ifelse(private$operator$negate == TRUE, yes = "1", no = "0"),
         cohort_window_logic = cohortWindowLogic,
         cohort_ids = private$operator$cohortIds,
         subset_length = ifelse(private$operator$cohortCombinationOperator == "any",

--- a/tests/testthat/test-Subsets.R
+++ b/tests/testthat/test-Subsets.R
@@ -567,6 +567,29 @@ test_that("Basic Negate logic check", {
 
   sqlForCohort1006 <- cohortDefinitionSet[cohortDefinitionSet$cohortId == 1006, "sql"]
   expect_true(grepl("AND NOT", sqlForCohort1006, ignore.case = TRUE))
+
+  # Ensure NEGATE = TRUE produces a RIGHT JOIN
+  op <- CohortGenerator::createCohortSubsetOperator(
+    name = "Test negate",
+    cohortIds = c(1),
+    windows = list(
+        CohortGenerator::createSubsetCohortWindow(
+        startDay = 1,
+        endDay = 365,
+        targetAnchor = "cohortEnd",
+        subsetAnchor = "cohortStart"
+      ),
+      CohortGenerator::createSubsetCohortWindow(
+        startDay = 366,
+        endDay = 99999,
+        targetAnchor = "cohortEnd",
+        subsetAnchor = "cohortStart"
+      )
+    ),
+    negate = TRUE,
+    cohortCombinationOperator = "any"
+  )
+  expect_true(grepl("RIGHT JOIN foo", op$getQueryBuilder(1)$getQuery("foo"), ignore.case = TRUE))
 })
 
 


### PR DESCRIPTION
Fixes bug identified by @ericaVoss where the `negate` parameter of `createCohortSubsetOperator` is not properly passed to the underlying SQL query.

